### PR TITLE
Update environment-setup.rst

### DIFF
--- a/site/source/developer-docs/getting-started/environment-setup.rst
+++ b/site/source/developer-docs/getting-started/environment-setup.rst
@@ -74,8 +74,6 @@ To install the SDK:
 .. code:: bash
 
     git clone --recursive https://github.com/Start9Labs/embassy-os.git && cd embassy-os/backend && ./install-sdk.sh
-    cd backend
-    ./install-sdk.sh
 
 To verify the installation, open a terminal window and run:
 

--- a/site/source/developer-docs/getting-started/environment-setup.rst
+++ b/site/source/developer-docs/getting-started/environment-setup.rst
@@ -73,8 +73,7 @@ To install the SDK:
 
 .. code:: bash
 
-    git clone https://github.com/Start9Labs/embassy-os.git
-    cd embassy-os
+    git clone --recursive https://github.com/Start9Labs/embassy-os.git && cd embassy-os/backend && ./install-sdk.sh
     cd backend
     ./install-sdk.sh
 

--- a/site/source/developer-docs/getting-started/environment-setup.rst
+++ b/site/source/developer-docs/getting-started/environment-setup.rst
@@ -46,7 +46,7 @@ To verify the installation, open a new terminal window and run:
 Docker
 ------
 
-`Docker <https://docs.docker.com/get-docker>`_ must be installed to your computer platform. It is needed to build an image for your package, which will be used to create the running instance of your package on EmbassyOS. In essence, it declares the necessary environment and building stages for your package to run.
+`Docker <https://docs.docker.com/get-docker>`_ must be installed on your computer. It is needed to build an image for your package, which will be used to create the running instance of your package on EmbassyOS. In essence, it declares the necessary environment and building stages for your package to run.
 
 We also recommend installing and using `Docker buildx <https://docs.docker.com/buildx/working-with-buildx/>`_, as this adds desirable new features to the Docker build experience. It is included by default with Docker Desktop for Windows and macOS.
 
@@ -74,6 +74,7 @@ To install the SDK:
 .. code:: bash
 
     git clone https://github.com/Start9Labs/embassy-os.git
+    cd embassy-os
     cd backend
     ./install-sdk.sh
 


### PR DESCRIPTION
- changed 'to' to 'on' (grammar)
- removed 'platform' (doesn't sound natural in 2022 english)
- added `cd embassy-os` because the user is still in root
- i had to close and open the terminal window at this point because `cargo`, which i had installed in the previous step, was not yet in the PATH
- might want to consider one-lining this block of commands? not sure if there's value in keeping them separate
  - something like `git clone https://github.com/Start9Labs/embassy-os.git | ./embassy-os/backend/install-sdk.sh` i think?
- under the EmbassyOS section, can you clarify something? is the "running instance" that you refer to the embassy-sdk that we just installed, or is it the instance running on the Embassy device?