### PR TITLE
Added instructions to include dependencies in Cargo.toml

### DIFF
--- a/site/source/developer-docs/build-package-example/02_create-service.rst
+++ b/site/source/developer-docs/build-package-example/02_create-service.rst
@@ -57,6 +57,14 @@ In ``main.rs`` add:
         }
     }
 
+And in ``Cargo.toml``, make sure your dependencies section looks like this:
+
+.. code:: toml
+
+    [dependencies]
+    hyper = { version = "0.14.4", features = ["server", "http1", "http2", "tcp", "stream"] }
+    tokio = { version = "1.4.0", features = ["full"] }
+
 
 **That's it!** We now have the code for our service.
 

--- a/site/source/developer-docs/build-package-example/02_create-service.rst
+++ b/site/source/developer-docs/build-package-example/02_create-service.rst
@@ -57,7 +57,7 @@ In ``main.rs`` add:
         }
     }
 
-And in ``Cargo.toml``, make sure your dependencies section looks like this:
+Finally, in our ``Cargo.toml``, we need to add some dependencies, which will look like this:
 
 .. code:: toml
 


### PR DESCRIPTION
When using these instructions, `cargo build` errors unless these dependencies are added.