### PR TITLE
tor-linux update for Fedora

### DIFF
--- a/site/source/user-manual/connecting/connecting-tor/tor-os/tor-linux.rst
+++ b/site/source/user-manual/connecting/connecting-tor/tor-os/tor-linux.rst
@@ -70,6 +70,8 @@ Running Tor on Linux
 
             - Fedora:
 
+            .. tip:: Latest Fedora versions have Tor package available for installation:
+
             .. code-block:: bash
 
                 [Tor]
@@ -80,8 +82,14 @@ Running Tor on Linux
                 gpgkey=https://rpm.torproject.org/fedora/public_gpg.key
                 cost=100
 
-        #. Then install the Tor package:
+        #. Install the Tor package:
 
             .. code-block:: bash
 
                 sudo dnf install tor
+
+        #. Then enable tor service:
+
+            .. code-block:: bash
+
+                sudo systemctl enable --now tor


### PR DESCRIPTION
Installing tor package for latest Fedora was not enough to successfully run tor service in the background that is why extra step is needed