### PR TITLE
add link to firefox manual cert addition

### DIFF
--- a/site/source/user-manual/connecting/connecting-lan/lan-os/lan-mac.rst
+++ b/site/source/user-manual/connecting/connecting-lan/lan-os/lan-mac.rst
@@ -33,3 +33,7 @@ Trusting Embassy CA on Mac
     .. figure:: /_static/images/ssl/macos/certificate_trusted.png
         :width: 60%
         :alt: Keychain menu trusted certificate
+
+No additional setup is required for most browsers and you will be able to safely connect over LAN. 
+
+If you wish to use Firefox (recommended) please follow the instructions :ref:`here <lan-ff>`.

--- a/site/source/user-manual/connecting/connecting-lan/lan-os/lan-mac.rst
+++ b/site/source/user-manual/connecting/connecting-lan/lan-os/lan-mac.rst
@@ -34,6 +34,6 @@ Trusting Embassy CA on Mac
         :width: 60%
         :alt: Keychain menu trusted certificate
 
-No additional setup is required for most browsers and you will be able to safely connect over LAN. 
+No additional setup is required for most browsers and you will now be able to safely connect to your Embassy over LAN.
 
-If you wish to use Firefox (recommended) please follow the instructions :ref:`here <lan-ff>`.
+For Firefox, you will need to follow :ref:`these <lan-ff>` instructions.


### PR DESCRIPTION
Tells users at the end of the adding Root CA to Keychain that they don't have anything more to do, unless they want to use Firefox - then provides link for that.