### PR TITLE
fix Documentation link in teach.rst

### DIFF
--- a/site/source/contribute/teach.rst
+++ b/site/source/contribute/teach.rst
@@ -7,5 +7,5 @@ Teach
 One of the most important things an individual can do to help the movement is to get the word out about sovereign computing and help others learn how to declare their own independence.
 
 - Write reviews or blog posts on Medium, Substack, Reddit, Mastodon, Twitter, etc.
-- Contribute to our `Documentation <https://github.com/Start9Labs/documentation">`_, whether you find a typo, have an FAQ to add, or tutorial to improve.  You can also find a link to submit a fix or report an issue near the top of this page (labeled ``Contribute``).
+- Contribute to our `Documentation <https://github.com/Start9Labs/documentation>`_, whether you find a typo, have an FAQ to add, or tutorial to improve.  You can also find a link to submit a fix or report an issue near the top of this page (labeled ``Contribute``).
 - Create videos - how-tos, comparisons, unboxings, and reviews are all helpful.


### PR DESCRIPTION
Old hyperlink led to a 404 page; fixed the link so that it takes one to the Documentation repo