### PR TITLE
Use existing user for installation instructions

### DIFF
--- a/site/source/developer-docs/build-package-example/10_install-package.rst
+++ b/site/source/developer-docs/build-package-example/10_install-package.rst
@@ -29,19 +29,19 @@ Now that we have a process for iterating on producing a valid package for Embass
     .. code:: bash
 
         # Confirm you can ssh into your Embassy
-        ssh root@<lan-url>
+        ssh start9@<lan-url>
         # Log out of Embassy SSH session
         exit
 
-        scp <package-id>.s9pk ssh root@<lan-url>:/working/directory/path
+        scp <package-id>.s9pk ssh start9@<lan-url>:/working/directory/path
 
-        eg. scp hello-world.s9pk ssh root@embassy-12345678.local:/root
+        eg. scp hello-world.s9pk ssh start9@embassy-12345678.local:~
 
 4. Finally, install the package on an Embassy device:
 
     .. code:: bash
 
-        ssh root@<lan-url>
+        ssh start9@<lan-url>
         # log in to the command line interface using the Embassy password
         embassy-cli auth login
         embassy-cli package install hello-world.s9pk


### PR DESCRIPTION
When new to Embassy one might not know that the default user is `start9`. These instructions refer to a `root` user that does not exist by default, however the user should be `start9`. Additionally, it's easier to refer to the home directory of that user than to some other directory.

Note that in https://start9.com/latest/user-manual/ssh `start9` is used as the user :)