### PR TITLE
Minor fixes to flashing guide

### DIFF
--- a/site/source/developer-docs/packaging.rst
+++ b/site/source/developer-docs/packaging.rst
@@ -40,7 +40,7 @@ Almost any type of open source software can be run on embassyOS. No matter what 
 
     - The interfaces supported are: HTTP, TCP, and REST APIs
 
-#. It can be compiled for ARM (``arm64v8``)
+#. It can be compiled for ARM (``arm64v8`` - namely, the Raspberry Pi) and/or x86_64 (``amd64`` - most desktops, laptops, and servers)
 #. It can be served over TOR
 #. It creates a container image that is optimized for size (under 1GB) to save device space and expedite installation time
 
@@ -199,7 +199,7 @@ After coding the build steps, build the Docker image using ``docker buildx``, re
 
         docker buildx build --tag start9/$(PKG_ID)/main:$(PKG_VERSION) --platform=linux/arm64 -o type=docker,dest=image.tar .
 
-The resulting ``image.tar`` artifact is the Docker image that needs to be included in the ``s9pk`` package. 
+The resulting ``docker-images/aarch64.tar`` or ``docker-images/x86_64.tar`` artifact (depending on if you used ``--platform=linux/arm64`` or ``--platform=linux/amd64`` is the Docker image that needs to be included in the ``s9pk`` package.
 
 .. _create-file-structure:
 

--- a/site/source/user-manual/flashing.rst
+++ b/site/source/user-manual/flashing.rst
@@ -16,41 +16,37 @@ Extracting the image
 Linux
 =====
 #. Download the ``eos.tar.gz`` file and open a terminal in the directory you save it to
-#. (Optional, but recommended) Verify the checksum against the one listed on GitHub:
-
-    .. code-block::
-
-        sha256sum eos.img.gz
-
 #. Extract with:
 
     .. code-block::
 
-       tar -xzvf eos.img.gz
+       tar -xzvf eos.tar.gz
+
+#. (Optional, but recommended) Verify the checksum against the one listed on GitHub:
+
+    .. code-block::
+
+        sha256sum eos.img
 
 Mac
 ===
 #. Download the ``eos.tar.gz`` file
+#. Right-click eos.tar.gz, click "open with," then click Archive Utility to extract
 #. (Optional, but recommended) Verify the checksum against the one listed on GitHub:
 
     .. code-block::
 
-        openssl dgst -sha256 eos.img.gz
-
-#. Right-click eos.tar.gz, click "open with," then click Archive Utility to extract
+        openssl dgst -sha256 eos.img
 
 Windows
 =======
 #. Download the ``eos.zip`` file
+#. Right-click eos.zip and click "Extract all"
 #. (Optional, but recommended) Verify the checksum against the one listed on GitHub:
 
     .. code-block::
 
-        Get-FileHash eos.zip
-
-#. Right-click eos.zip and click "Extract all"
-
-In all cases you will be left with the file ``eos.img``
+        Get-FileHash eos.img
 
 Installing embassyOS
 --------------------


### PR DESCRIPTION
Fix some errors and rearrange steps such that `img` is checksummed instead of archive