### PR TITLE
Fix (very) minor typo in developer docs -> docker installation instructions

### DIFF
--- a/site/source/developer-docs/packaging.rst
+++ b/site/source/developer-docs/packaging.rst
@@ -99,7 +99,7 @@ Dependencies - Required
 
     .. code-block::
         
-        curl -fsSL https://get.docker.com -o | bash
+        curl -fsSL https://get.docker.com | bash
         sudo usermod -aG docker "$USER"
         exec sudo su -l $USER
     

--- a/site/source/developer-docs/packaging.rst
+++ b/site/source/developer-docs/packaging.rst
@@ -99,7 +99,7 @@ Dependencies - Required
 
     .. code-block::
         
-        curl -fsSL https://get.docker.com -o- | bash
+        curl -fsSL https://get.docker.com -o | bash
         sudo usermod -aG docker "$USER"
         exec sudo su -l $USER
     


### PR DESCRIPTION
The trailing slash in the curl params has no effect, but it threw me off. 

This PR goes hand in hand with https://github.com/Start9Labs/hello-world-wrapper/pull/24