### PR TITLE
Update ssh over tor to include macOS

### DIFF
--- a/site/source/user-manual/ssh.rst
+++ b/site/source/user-manual/ssh.rst
@@ -120,6 +120,14 @@ Setup
 
                 sudo pacman -S torsocks
 
+        .. group-tab:: macOS
+
+            .. code-block:: bash
+
+                brew install openssh torsocks
+                exec sudo su -l $USER
+
+
 #. SSH in:
 
     .. warning:: The changes you make here are on the overlay and won't persist after a restart of your Embassy.

--- a/site/source/user-manual/ssh.rst
+++ b/site/source/user-manual/ssh.rst
@@ -106,17 +106,15 @@ Setup
 
 #. First, you need to enable SSH over tor in your Embassy:
 
-    .. warning:: The changes you make here are on the overlay and won't persist after a restart of your Embassy.
-
     .. code-block:: bash
 
         ssh start9@embassy-xxxxxxx.local
 
-#. Elevate yourself to root for the rest of the ssh session:
+#. Elevate yourself to root in chroot edit mode:
 
     .. code-block:: bash
 
-        sudo -i
+        sudo /usr/lib/embassy/scripts/chroot-and-upgrade
 
 #. Using Vim or Nano, add the following 2 lines to ``/etc/tor/torrc``
 
@@ -131,17 +129,19 @@ Setup
 
             echo "HiddenServiceDir /var/lib/tor/ssh" >> /etc/tor/torrc && echo "HiddenServicePort 22 127.0.0.1:22" >> /etc/tor/torrc
 
-#. Reload the Tor configuration with your edits:
+#. Restart your Embassy by exiting chroot edit mode:
 
     .. code-block:: bash
 
-        systemctl reload tor
+        exit
 
-#. Gather the ".onion" address you just created:
+#. Ssh in to your embassy again and gather the ".onion" address that was generated:
 
     .. code-block:: bash
 
         cat /var/lib/tor/ssh/hostname
+
+.. note:: Your newly generated .onion address is unique for SSH access only and should not be confused with the main .onion address for the Embassy.
 
 Configure local SSH client
 .....

--- a/site/source/user-manual/ssh.rst
+++ b/site/source/user-manual/ssh.rst
@@ -44,7 +44,7 @@ Creating an SSH Key (Linux/Mac)
 Registering an SSH Key
 ----------------------
 
-#. In your Embassy's web interface, navigate to *System > SSH*.
+#. In your Start9 server's web interface, navigate to *System > SSH*.
 #. Click "Add New Key".
 #. Back in the terminal of your workstation, display and copy your SSH *public* key (created above):
 
@@ -66,26 +66,26 @@ Registering an SSH Key
 
           ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINH3tqX71XsPlzYhhoo9CqAP2Yx7gsGTh43bQXr1zqoq user@ema.il
 
-#. Paste that line into the `Add New Key` text field of your Embassy
+#. Paste that line into the `Add New Key` text field of your Start9 server
 
     .. figure:: /_static/images/walkthrough/ssh_key_add.jpg
 
 #. Click **Submit**
 
-You are now ready to SSH into your Embassy!
+You are now ready to SSH into your server!
 
 .. _connecting-via-ssh:
 
 Connecting via CLI (Linux/Mac)
 ------------------------------
 
-#. You can now access your Embassy from the command line (Linux and Mac) using:
+#. You can now access your Start9 server from the command line (Linux and Mac) using:
 
     .. code-block:: bash
 
-        ssh start9@<LAN URL>
+        ssh start9@<SERVER-HOSTNAME>
 
-Replacing ``<LAN URL>`` with your Embassy's LAN (``embassy-xxxxxxx.local``) address
+Replacing ``<SERVER-HOSTNAME>`` with your Start9 server's LAN (``server-hostname.local``) hostname
 
 .. note:: If you get a scary looking warning that says something like "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!" - fear not!  This is most likely happening because you have recently reflashed or did an update from pre-v0.3.3, which would cause a change in the key for your device's hostname (e.g. `xxxxxxxx.local`) or IP address (e.g. `192.168.1.x`).  The solution is to delete the existing entry from your `known_hosts` file, which is typically located at `~/.ssh/known_hosts`.  This should be named in the warning, along with a helpful line number (in case your file is lengthy).
 
@@ -97,20 +97,20 @@ Community member `BrewsBitcoin <https://brewsbitcoin.com>`_ has created `a guide
 Using SSH Over Tor
 ------------------
 
-.. note:: The following guide requires that you have already added an :ref:`SSH key to your Embassy<ssh>`.
+.. note:: The following guide requires that you have already added an :ref:`SSH key to your Start9 server<ssh>`.
 
-.. caution:: SSH over Tor is only supported on Linux and macOS, though it may also work on Windows with `Torifier <https://torifier.com/>`_.
+.. caution:: SSH over Tor is only supported on Linux and macOS, although it can also work on Windows with in PuTTY `like this <https://tor.stackexchange.com/a/143>`_.  Note that those instructions use port 9150 but we've configured Tor in Windows on the traditional port: ``9050``.
 
 Setup
 .....
 
-#. First, you need to enable SSH over tor in your Embassy:
+#. First, you need to enable SSH over tor on your Start9 server:
 
     .. code-block:: bash
 
-        ssh start9@embassy-xxxxxxx.local
+        ssh start9@SERVER-HOSTNAME.local
 
-#. Elevate yourself to root in chroot edit mode:
+#. Elevate yourself to root in chroot edit mode (which will make your changes persist across reboots):
 
     .. code-block:: bash
 
@@ -129,19 +129,19 @@ Setup
 
             echo "HiddenServiceDir /var/lib/tor/ssh" >> /etc/tor/torrc && echo "HiddenServicePort 22 127.0.0.1:22" >> /etc/tor/torrc
 
-#. Restart your Embassy by exiting chroot edit mode:
+#. Restart your Start9 server by exiting chroot edit mode:
 
     .. code-block:: bash
 
         exit
 
-#. Ssh in to your embassy again and gather the ".onion" address that was generated:
+#. SSH in to your Start9 server again and gather the ".onion" address that was generated:
 
     .. code-block:: bash
 
         cat /var/lib/tor/ssh/hostname
 
-.. note:: Your newly generated .onion address is unique for SSH access only and should not be confused with the main .onion address for the Embassy.
+.. note:: Your newly generated .onion address is unique for SSH access only and should not be confused with the main .onion address for the server.
 
 Configure local SSH client
 .....

--- a/site/source/user-manual/ssh.rst
+++ b/site/source/user-manual/ssh.rst
@@ -99,36 +99,12 @@ Using SSH Over Tor
 
 .. note:: The following guide requires that you have already added an :ref:`SSH key to your Embassy<ssh>`.
 
-.. caution:: SSH over Tor is only supported on Linux, though it may also work on Windows with `Torifier <https://torifier.com/>`_.
+.. caution:: SSH over Tor is only supported on Linux and macOS, though it may also work on Windows with `Torifier <https://torifier.com/>`_.
 
 Setup
 .....
 
-#. First, you'll need one dependency, ``torsocks``, which will allow you to use SSH over Tor on the machine that you want access with. Select your Linux flavor to install:
-
-    .. tabs::
-
-        .. group-tab:: Debian / Ubuntu
-
-            .. code-block:: bash
-
-                sudo apt install torsocks
-
-        .. group-tab:: Arch / Garuda / Manjaro
-
-            .. code-block:: bash
-
-                sudo pacman -S torsocks
-
-        .. group-tab:: macOS
-
-            .. code-block:: bash
-
-                brew install openssh torsocks
-                exec sudo su -l $USER
-
-
-#. SSH in:
+#. First, you need to enable SSH over tor in your Embassy:
 
     .. warning:: The changes you make here are on the overlay and won't persist after a restart of your Embassy.
 
@@ -167,6 +143,20 @@ Setup
 
         cat /var/lib/tor/ssh/hostname
 
+Configure local SSH client
+.....
+
+#. You'll need to add the following configuration to your SSH config file, which will allow you to use SSH over Tor on any Unix-based system:
+
+    .. code-block:: bash
+
+        echo -e "Host *.onion\n  ProxyCommand nc -xlocalhost:9050 %h %p\n" >> ~/.ssh/config
+
+    This command adds a wildcard setting for .onion domains to your SSH config file. Any .onion domains you connect to using SSH will use the specified proxy command.
+
+    Note: You only need to run this command only once to set up the SSH Over Tor configuration.
+
+
 Access
 ======
 
@@ -174,4 +164,4 @@ To log in, simply use the following command, using the ".onion" hostname you pri
 
     .. code-block::
 
-        torsocks ssh start9@xxxxxxxxxxxxxxxxx.onion
+        ssh start9@xxxxxxxxxxxxxxxxx.onion


### PR DESCRIPTION
Adding ssh over tor for macOS support.
In case of macOS, I had to reload the environment for `torsocks` command to be available right away.
extra `openssh` brew package is needed to fix this:
```
ERROR: /usr/bin/ssh is located in a directory protected by Apple's System Integrity Protection.
```