### PR TITLE
decentralize documentation links

### DIFF
--- a/site/source/contribute/decentralize.rst
+++ b/site/source/contribute/decentralize.rst
@@ -7,6 +7,6 @@ embassyOS allows users to swap to an alternative Marketplace in case they want a
 
     - In order to change to an unofficial Marketplace, you can see our documentation :ref:`here <alt-marketplaces>`.
 
-You can even run your own Marketplace using your Embassy!  On each service's GitHub Releases page, such as `Bitcoin <https://github.com/Start9Labs/bitcoind-wrapper/releases/tag/v23.0.0>`_ for example, you will find the ``.s9pk`` Asset.  You can download this package, upload to a folder on `File Browser <https://marketplace.start9.com/marketplace/filebrowser>`_, and then host it over :ref:`Tor<tor>` using `Embassy Pages <https://marketplace.start9.com/marketplace/embassy-pages>`_!
+You can even run your own Marketplace using your Embassy!  On each service's GitHub Releases page, such as `Bitcoin <https://github.com/Start9Labs/bitcoind-wrapper/releases/tag/v23.0.0>`_ for example, you will find the ``.s9pk`` Asset.  You can download this package, upload to a folder on `File Browser <https://marketplace.start9.com/marketplace/filebrowser>`_ or `Nextcloud <https://marketplace.start9.com/marketplace/nextcloud>`_, and then host it over :ref:`Tor<tor>` using `Embassy Pages <https://marketplace.start9.com/marketplace/embassy-pages>`_!
 
 A full specification to mimic our production Marketplace is forthcoming.

--- a/site/source/contribute/decentralize.rst
+++ b/site/source/contribute/decentralize.rst
@@ -7,6 +7,6 @@ embassyOS allows users to swap to an alternative Marketplace in case they want a
 
     - In order to change to an unofficial Marketplace, you can see our documentation :ref:`here <alt-marketplaces>`.
 
-You can even run your own Marketplace using your Embassy!  On each service's GitHub Releases page, such as `Bitcoin <https://github.com/Start9Labs/bitcoind-wrapper/releases/tag/v23.0.0>`_ for example, you will find the ``.s9pk`` Asset.  You can download this package, upload to a folder on `File Browser <https://marketplace.start9.com/filebrowser>`_, and then host it over :ref:`Tor<tor>` using `Embassy Pages <https://marketplace.start9.com/embassy-pages>`_!
+You can even run your own Marketplace using your Embassy!  On each service's GitHub Releases page, such as `Bitcoin <https://github.com/Start9Labs/bitcoind-wrapper/releases/tag/v23.0.0>`_ for example, you will find the ``.s9pk`` Asset.  You can download this package, upload to a folder on `File Browser <https://marketplace.start9.com/filebrowser>`_, and then host it over :ref:`Tor<tor>` using `Embassy Pages <https://marketplace.start9.com/marketplace/embassy-pages>`_!
 
 A full specification to mimic our production Marketplace is forthcoming.

--- a/site/source/contribute/decentralize.rst
+++ b/site/source/contribute/decentralize.rst
@@ -7,6 +7,6 @@ embassyOS allows users to swap to an alternative Marketplace in case they want a
 
     - In order to change to an unofficial Marketplace, you can see our documentation :ref:`here <alt-marketplaces>`.
 
-You can even run your own Marketplace using your Embassy!  On each service's GitHub Releases page, such as `Bitcoin <https://github.com/Start9Labs/bitcoind-wrapper/releases/tag/v23.0.0>`_ for example, you will find the ``.s9pk`` Asset.  You can download this package, upload to a folder on `File Browser <https://marketplace.start9.com/filebrowser>`_, and then host it over :ref:`Tor<tor>` using `Embassy Pages <https://marketplace.start9.com/marketplace/embassy-pages>`_!
+You can even run your own Marketplace using your Embassy!  On each service's GitHub Releases page, such as `Bitcoin <https://github.com/Start9Labs/bitcoind-wrapper/releases/tag/v23.0.0>`_ for example, you will find the ``.s9pk`` Asset.  You can download this package, upload to a folder on `File Browser <https://marketplace.start9.com/marketplace/filebrowser>`_, and then host it over :ref:`Tor<tor>` using `Embassy Pages <https://marketplace.start9.com/marketplace/embassy-pages>`_!
 
 A full specification to mimic our production Marketplace is forthcoming.


### PR DESCRIPTION
Small documentation fix for embassy-pages link

expected behavior: Link should direct the user to the embassy-pages service in the documentation