### PR TITLE
add note about removing previous exceptions

### DIFF
--- a/site/source/user-manual/connecting/connecting-lan/lan-os/lan-linux.rst
+++ b/site/source/user-manual/connecting/connecting-lan/lan-os/lan-linux.rst
@@ -59,7 +59,7 @@ Here we will insert your Start9 server's CA certificate into Linux's trust store
 
         In the output it should say ``1 added`` if it was successful.
 
-        Now restart Firefox (or other Mozilla application) and login to your server using ``https://``.  No SSL warning should appear.  If you still encounter issues, `contact support <https://start9.com/contact>`_.
+        Now restart Firefox (or other Mozilla application) and login to your server using ``https://``.  No SSL warning should appear.  If you previously added an eception, you may need to remove it by clicking the lock icon in the address bar. If you still encounter issues, `contact support <https://start9.com/contact>`_.
 
     .. group-tab:: Arch/Garuda
 


### PR DESCRIPTION
I noticed that when I followed these steps, everything worked fine, but Firefox still displayed hazard icon over the lock icon in the address bar. When I clicked it, it showed that it still wasn't safe because it was allowed by exception. A button is present that says "Remove Exception" which I did and the page refreshed and displayed no warning/hazard. 