### PR TITLE
fix broken link from diy

### DIFF
--- a/site/source/diy/diy-x86.rst
+++ b/site/source/diy/diy-x86.rst
@@ -41,7 +41,7 @@ Flash and Install StartOS
 -------------------------
 .. topic-box::
   :title: Flashing (x86_64)
-  :link: /latest/user-manual/flashing/flashing-x86
+  :link: /latest/guides/flashing/flashing-x86
   :icon: scylla-icon scylla-icon--overview
   :class: large-4
   :anchor: View Guide


### PR DESCRIPTION
clicking on flashing (x86_64) from diy is currently broken: https://docs.start9.com/latest/diy/diy-x86