### PR TITLE
advacnced/dev-tools/embassyd: Replacing embassyd references with startd

### DIFF
--- a/site/source/developer-docs/advanced/dev-tools/embassyd.rst
+++ b/site/source/developer-docs/advanced/dev-tools/embassyd.rst
@@ -4,18 +4,18 @@
 StartOS Daemon
 ==============
 
-.. warning:: This is for advanced users only!! Anything you do while SSH'd into your Embassy is NOT SUPPORTED, unless under the guidance of a Start9 technician.
+.. warning:: This is for advanced users only!! Anything you do while SSH'd into StartOS is NOT SUPPORTED, unless under the guidance of a Start9 technician.
 
-``embassyd`` is the daemon that runs everything that could be considered StartOS.
+``startd`` is the daemon that runs everything that could be considered StartOS.
 
-When SSH'd into your Start9 server, you may see the status of EmbassyD with the following:
+When SSH'd into your Start9 server, you may see the status of ``startd`` with the following:
 
     .. code-block:: bash
 
-        systemctl status embassyd
+        systemctl status startd
 
 If you need to restart the daemon for some reason, you can do so with:
 
     .. code-block:: bash
 
-        systemctl restart embassyd
+        systemctl restart startd


### PR DESCRIPTION
Update this page:
https://docs.start9.com/latest/developer-docs/advanced/dev-tools/embassyd