### PR TITLE
Update ca-ios.rst

### DIFF
--- a/site/source/guides/device-guides/ios/ca-ios.rst
+++ b/site/source/guides/device-guides/ios/ca-ios.rst
@@ -5,7 +5,7 @@ Trusting Your Server's Root CA on iOS
 =====================================
 Complete this guide to trust your server's Root Certificate Authority (Root CA) on iOS.
 
-.. note:: This guide only applies to iOS v15+. For v14, see the `v14 guide </0.3.1.x/user-manual/connecting/connecting-lan/lan-os/lan-ios>`_.
+.. note:: This guide only applies to iOS v15+. For v14, see the `v14 guide <https://docs.start9.com/0.3.1.x/user-manual/connecting/connecting-lan/lan-os/lan-ios`_.
 
 #. Ensure you have already `downloaded your server's Root CA </getting-started/trust-ca/#download-your-server-s-root-ca>`_
 


### PR DESCRIPTION
Link lead to a 404 page.

I was going through the 'Trust Your Root CA on iOS' guide (https://docs.start9.com/latest/guides/device-guides/dg-ios/lan-ios#lan-ios) and noticed that the when you click through to 'For older versions, see the v14 guide.' (https://docs.start9.com/0.3.1.x/user-manual/connecting/connecting-lan/lan-os/lan-ios) has a Caution box at the top with 'You are not reading the latest stable version of this documentation. If you want up-to-date information, please have a look at 0.3.4.4.' stated but when you click on 0.3.4.4. it takes you back to the index page (https://docs.start9.com/latest/index).