### PR TITLE
Update to bug on lan-ios.rst

### DIFF
--- a/site/source/guides/device-guides/dg-ios/lan-ios.rst
+++ b/site/source/guides/device-guides/dg-ios/lan-ios.rst
@@ -5,7 +5,7 @@ Trust Your Root CA on iOS
 =========================
 Complete this guide to download your Start9 server's Root Certificate Authority (CA), and trust it on your client device (iOS).  This allows you to use encrypted ``https`` connections to your ``.local`` (LAN) and ``.onion`` (tor) server addresses, access services on LAN, and enhances performance on tor.  The Root CA was created by your server when you perfomed the initial setup, and signs the certificate of your server's main UI, as well as that of all services.
 
-This applies to iOS v15 and v16.  For older versions, see the `v14 guide </0.3.1.x/user-manual/connecting/connecting-lan/lan-os/lan-ios>`_.
+This applies to iOS v15 and v16.  For older versions, see the `v14 guide <https://docs.start9.com/0.3.1.x/user-manual/connecting/connecting-lan/lan-os/lan-ios>`_.
 
 #. Download the certificate to your Downloads folder
 


### PR DESCRIPTION
Fixed the broken link that wasn't pointing anywhere.

I was going through the 'Trust Your Root CA on iOS' guide (https://docs.start9.com/latest/guides/device-guides/dg-ios/lan-ios#lan-ios) and noticed that the when you click through to 'For older versions, see the v14 guide.' (https://docs.start9.com/0.3.1.x/user-manual/connecting/connecting-lan/lan-os/lan-ios) has a Caution box at the top with 'You are not reading the latest stable version of this documentation. If you want up-to-date information, please have a look at 0.3.4.4.' stated but when you click on 0.3.4.4. it takes you back to the index page (https://docs.start9.com/latest/index).