### PR TITLE
Nextcloud Server WebDAV path and username fix ```0344```

### DIFF
--- a/site/source/guides/service-guides/nextcloud/nextcloud-setup/nextcloud-android.rst
+++ b/site/source/guides/service-guides/nextcloud/nextcloud-setup/nextcloud-android.rst
@@ -132,7 +132,7 @@ In order to sync calendars and contacts with your Android device, follow the ste
 
    - If you are NOT using the Nextcloud app already, then open DAVx5 and after going through the introduction (optionally selecting additional features), tap the "+" icon to add a new account, then select "Login with URL and user name," and fill in the following fields:
 
-     - Base URL - Enter your Nextcloud LAN address from "Interfaces" on your Nextcloud service page and add `/remote.php/dav` after `.local`
+     - Base URL - Enter your Nextcloud WebDAV Base LAN URL (found in "Properties" in the Nextcloud service page).
 
      - User name - Your Nextcloud user (defaults are found in "Properties" on your Nextcloud service page)
 

--- a/site/source/guides/service-guides/nextcloud/nextcloud-setup/nextcloud-ios.rst
+++ b/site/source/guides/service-guides/nextcloud/nextcloud-setup/nextcloud-ios.rst
@@ -100,9 +100,9 @@ First head into the top-righthand menu of your Nextcloud's WebUI and click "Apps
 
 3. Enter the following fields and tap "Next":
 
-  - Server - Enter your Nextcloud server LAN URL (found in "Interfaces" in the Nextcloud service page), and add --> **`/remote.php/dav`** <-- after `.local`.
+  - Server - Enter your Nextcloud WebDAV Base LAN URL (found in "Properties" in the Nextcloud service page).
   
-  - User name - The default user is "admin," but this is your user within Nextcloud, so be sure it is the correct user if you have more than one.
+  - User name - The default user is "embassy," but this is your user within Nextcloud, so be sure it is the correct user if you have more than one.
   
   - Password - Your Nextcloud user's password (Default found in "Properties" in the Nextcloud service page).
 


### PR DESCRIPTION
Nextcloud Server WebDAV path now taken from "Properties" tab and default user name changed to "embassy" for iOS.