### PR TITLE
Update start-sdk installation instruction

### DIFF
--- a/site/source/developer-docs/packaging.rst
+++ b/site/source/developer-docs/packaging.rst
@@ -181,8 +181,8 @@ Dependencies - Required
     .. code-block::
 
         git clone https://github.com/Start9Labs/start-os.git && \
-         cd start-os && make frontends && mkdir -p ./frontend/dist/static && \
-         cd ./backend && ./install-sdk.sh
+         cd start-os && git submodule update --init --recursive && \
+         make sdk
 
     Initialize sdk & verify install
 


### PR DESCRIPTION
I was going through the installation instructions to set up a development environment on Ubuntu for StartOS 0.3.5, when I noticed that the instructions to clone and install the start-sdk are outdated.