### PR TITLE
Fix typo referring to Android in iOS Tor doc

### DIFF
--- a/site/source/device-guides/ios/tor-ios.rst
+++ b/site/source/device-guides/ios/tor-ios.rst
@@ -4,7 +4,7 @@
 Running Tor on iOS
 ==================
 
-Orbot is a system-wide proxy for your Android device that enables communications over Tor.
+Orbot is a system-wide proxy for your iOS device that enables communications over Tor.
 
 #. Download and install `Orbot from the Apple appstore <https://apps.apple.com/us/app/orbot/id1609461599>`_.
 #. Open Orbot and tap on "Settings".


### PR DESCRIPTION
The first sentence of the iOS Tor document refers to Android where iOS was intended.