### PR TITLE
Change backup media filesystem recommendation to ext4

### DIFF
--- a/site/source/user-manual/backups/backup-create.rst
+++ b/site/source/user-manual/backups/backup-create.rst
@@ -14,7 +14,7 @@ Physical Drive
 
 .. warning:: Backing up to USB thumb drive or SD card media is highly discouraged, as low-quality flash memory is easily corruptible.
 
-#. Ensure your backup drive is properly formatted. The recommended format at this time is ``exFAT``. **Do not** use ``fat32``.
+#. Ensure your backup drive is properly formatted. The recommended format at this time is ``EXT4``. **Do not** use ``fat32`` or ``exFAT``.
 
 #. Plug your physical drive into your server.
 


### PR DESCRIPTION
Something in the EXT series seems to be the way to go since it won't fail when certain services that use rsync make their backups.  Also there's at least open source drivers that windows people can use to access it, even if they can't natively.

I think the ultimate solution is however Aiden is planning to fix backups with the filesystem inside filesystem structure that way the backups themselves don't have to store metadata about the files that are backed up.  So hopefully we can change this recommendation back to exFAT in v040 at the latest.