### PR TITLE
Added mount drive step for physical drive on backup create

### DIFF
--- a/site/source/user-manual/backups/backup-create.rst
+++ b/site/source/user-manual/backups/backup-create.rst
@@ -20,6 +20,8 @@ Physical Drive
 
     .. warning:: If you are using a low-powered device (like a RasPi), this drive MUST have external power, or be connected via a powered USB hub in order to prevent any data corruption due to power constraints!  Server One and Server Pure users can safely ignore this warning.
 
+#. :ref:`Mount the drive<backup-mount>` on your server.
+
 
 Network Folder
 ..............


### PR DESCRIPTION
The steps to prepare a physical drive for backups was missing instructions to mount the drive on the server. This has been added.