### PR TITLE
Update/flashing guide p2

### DIFF
--- a/site/source/flashing-guides/firmware-pure.rst
+++ b/site/source/flashing-guides/firmware-pure.rst
@@ -1,16 +1,18 @@
 .. _flashing-firmware-pure:
 
-======================
-Firmware (Server Pure)
-======================
+============================
+Firmware (Server Pure only)
+============================
 This page is for Server Pure / Purism Librem Mini users ONLY.  This firmware is custom for these devices.
 
-Generally, you do not need to manually flash your device using this guide, as the firmware is now automatically updated on supported devices.  Please only use this method if directed by a Start9 Support Technician.
+Generally, you do not need to manually flash your device using this guide, as the firmware is now automatically updated on supported devices.  Please only use this method if directed by a Start9 Support Technician. **If you were told to flash your device, you are looking for the StartOS flashing guides instead**.
 
 Downloading the right firmware
 ------------------------------
 
-The source code can be viewed on Purism's `firmware git repo <https://source.puri.sm/firmware/releases/-/tree/master/librem_mini_v2/custom>`_.  You will need a USB flash drive, formatted FAT32, to flash the firmware to your server.
+The source code can be viewed on Purism's `firmware git repo <https://source.puri.sm/firmware/releases/-/tree/master/librem_mini_v2/custom>`_.  You will need a USB flash drive, formatted FAT32, to flash the firmware to your server. 
+
+"Windows" refers to the plastic strips on the side of your Server Pure.
 
 
 
@@ -18,13 +20,13 @@ The source code can be viewed on Purism's `firmware git repo <https://source.pur
 
     .. group-tab:: White Windows
         
-        Download the latest firmware from Purism's git repository: `Standard release <https://source.puri.sm/firmware/releases/-/blob/75631ad6dcf7e6ee73e06a517ac7dc4e017518b7/librem_mini_v2/custom/pureboot-librem_mini_v2-basic_usb_autoboot-Release-29.zip>`_.
+        Download firmware from Purism's git repository: `Standard release <https://source.puri.sm/firmware/releases/-/blob/75631ad6dcf7e6ee73e06a517ac7dc4e017518b7/librem_mini_v2/custom/pureboot-librem_mini_v2-basic_usb_autoboot-Release-29.zip>`_.
         
     .. group-tab:: Dark Windows
         
         This model of the Server Pure (formally Embassy Pro) supports WiFi. You may choose between firmware that allows for WiFi and firmware that disables and locks it down.
 
-        Download the latest firmware from Purism's git repository:
+        Download firmware from Purism's git repository:
         `Standard release <https://source.puri.sm/firmware/releases/-/blob/75631ad6dcf7e6ee73e06a517ac7dc4e017518b7/librem_mini_v2/custom/pureboot-librem_mini_v2-basic_usb_autoboot-Release-29.zip>`_
         or `Jailed WiFi <https://source.puri.sm/firmware/releases/-/blob/75631ad6dcf7e6ee73e06a517ac7dc4e017518b7/librem_mini_v2/custom/pureboot-librem_mini_v2-basic_usb_autoboot_blob_jail-Release-29.zip>`_.
 

--- a/site/source/flashing-guides/index.rst
+++ b/site/source/flashing-guides/index.rst
@@ -4,14 +4,14 @@
 Flashing Guides
 ===============
 
-Here you will find our flashing guides for the Raspberry Pi and x86_64 (most desktops, laptops, mini PCs, servers, etc) architectures. Librem Mini owners can use the firmware flashing guide to get StartOS-specific firmware.
+Here you will find our flashing guides for the Raspberry Pi and x86_64/ARM (most desktops, laptops, mini PCs, servers, etc) architectures. Librem Mini owners can use the firmware flashing guide to get StartOS-specific firmware if told to do so by a Start9 Support Technician.
 
 ____________
 
 StartOS
 --------------
 
-Download the latest version of StartOS to flash to a USB thumb drive (x86) or to a microSD card (Raspberry Pi)
+Download the latest version of StartOS to flash to a USB thumb drive (x86/ARM) or to a microSD card (Raspberry Pi)
 
   .. toctree::
     :maxdepth: 1

--- a/site/source/flashing-guides/os-pi.rst
+++ b/site/source/flashing-guides/os-pi.rst
@@ -7,8 +7,8 @@ This guide is for flashing StartOS to a microSD card in order to install it on a
 
 .. warning:: If you are running in a "Lite" configuration (everything on an SD card), then flashing that SD card in the manner proscribed below WILL ERASE ALL YOUR DATA!  If you need to reflash and you are NOT using an external SSD (ie. you have a Server Lite), please `contact support <https://start9.com/contact>`_ for assistance instead.
 
-Getting StartOS
----------------
+Download StartOS
+-----------------
 Visit the `Github release page <https://github.com/Start9Labs/start-os/releases/latest>`_ to find the latest StartOS release.
 
 At the bottom of the page, under "Assets," download the ``startos-..._raspberrypi.img.gz`` file.
@@ -16,6 +16,12 @@ At the bottom of the page, under "Assets," download the ``startos-..._raspberryp
     .. figure:: /_static/images/flashing/raspi-asset.png
       :width: 60%
       :alt: Raspberry Pi Asset
+
+____________
+
+
+Verify (optional)
+-----------------
 
 Select your OS to continue:
 
@@ -45,9 +51,11 @@ Select your OS to continue:
 
                 cd Downloads
                 Get-FileHash startos-0.3.4.2-efc56c0-20230525_raspberrypi.img.gz
+____________
 
-Installing StartOS
-------------------
+Flash
+------
+
 Once you have the StartOS ``.img.gz`` file, you will need to flash it onto a microSD card.
 
 #. Download and install `balenaEtcher <https://www.balena.io/etcher/>`_ onto your Linux, Mac, or Windows computer.
@@ -68,6 +76,8 @@ Once you have the StartOS ``.img.gz`` file, you will need to flash it onto a mic
 
 #. Click "Flash!". You may be asked to approve the unusually large disk target and/or enter your password. Both are normal.
 
-#. After the flash completes, you may remove the newly flashed micro SD card from any adapter, and insert it into your server's SD card slot.
+____________
 
-#. Finally, continue to the :ref:`Initial Setup <initial-setup>`, :ref:`Manual Update <manual-update>`, or :ref:`Reset Password <reset-password>` instructions - depending on your need.
+Install
+--------
+#. For the Raspberry Pi, flashing and installing are essentially the same thing. Simply remove the newly-flashed microSD card and insert it into your Raspberry Pi.

--- a/site/source/flashing-guides/os-x86.rst
+++ b/site/source/flashing-guides/os-x86.rst
@@ -1,14 +1,14 @@
 .. _flashing-os-x86:
 
 =============
-StartOS (x86)
+StartOS (x86/ARM)
 =============
-This guide is for flashing StartOS to a USB drive in order to install it to an x86_64 architecture device.  This will include most desktops, laptops, mini PCs, and servers.  For an up-to-date list of known-good hardware, please check out this `forum post <https://community.start9.com/t/known-good-hardware-master-list-hardware-capable-of-running-startos/>`_.
+This guide is for flashing StartOS to a USB drive in order to install it to an x86_64 or ARM architecture device. This will include most desktops, laptops, mini PCs, and servers.
 
  .. note:: You will need a USB drive of at least 8GB in size
 
-Getting StartOS
----------------
+Download StartOS
+-----------------
 Visit the `Github release page <https://github.com/Start9Labs/start-os/releases/latest>`_ to find the latest StartOS release.
 
 At the bottom of the page, under "Assets," download the ``x86_64.iso`` or ``x86_64-nonfree.iso`` file.
@@ -25,12 +25,24 @@ Server One (*x86_64-nonfree.iso*)
 
 The ``x86_64-nonfree.iso`` image contains non-free (closed-source) software. This is needed for the Server One and most DIY hardware, especially for graphics and/or network device support. 
 
-*For a DIY virtual machine build, if using a x86 chip, you'd use the non-free image if the free version does not work for you, but for an Apple Silicon chip you would use* ``aarch64.iso`` *and follow* `this guide <https://blog.start9.com/running-startos-on-apple-silicon/>`_.
-
-
     .. figure:: /_static/images/flashing/x86_64-asset.png
         :width: 90%
 
+
+-------------------------------------------------------------
+DIY Hardware (*x86_64-nonfree.iso* or *aarch64-nonfree.iso*)
+-------------------------------------------------------------
+
+For an up-to-date list of known-good hardware, please check out this `forum post <https://community.start9.com/t/known-good-hardware-master-list-hardware-capable-of-running-startos/>`_.
+
+
+For a DIY virtual machine build, if using a x86 chip, you'd use the non-free image if the free version does not work for you, but for an Apple Silicon chip you would use ``aarch64.iso`` and follow `this guide <https://blog.start9.com/running-startos-on-apple-silicon/>`_.
+
+____________
+
+
+Verify (optional)
+-----------------
 Select the client OS you are using to continue:
 
 .. tabs::
@@ -59,8 +71,12 @@ Select the client OS you are using to continue:
                 cd Downloads
                 Get-FileHash startos-0.3.4.2-efc56c0-20230525_x86_64.iso
 
-Installing StartOS
-------------------
+____________
+
+
+Flash
+------
+
 Once you have the StartOS image, you will need to flash it onto your USB drive.
 
 #. Download `balenaEtcher <https://www.balena.io/etcher/>`_ onto your Linux, Mac, or Windows computer.
@@ -81,12 +97,17 @@ Once you have the StartOS image, you will need to flash it onto your USB drive.
 
 #. Click "Flash!". You may be asked to approve the unusually large disk target and/or enter your password. Both are normal.
 
-#. After this completes, you may remove the newly flashed drive from your computer, and insert it into the device you intend to install StartOS onto.
+____________
 
-#. Plug the USB drive into the device and power on. Follow the on-screen instructions to Install StartOS (use "Re-Install" to preserve data, or "Factory Reset" to wipe the device). After install is complete, you will be prompted to remove your USB drive.
+Install
+--------
 
-    .. note:: Always prefer the fastest available USB 3.0+ port - typically this is blue or labeled "SS" (SuperSpeed)
+#. Remove the newly-flashed USB drive from your computer and plug it into your server. Choose the fastest available USB 3.0+ port - typically this is blue or labeled "SS" (SuperSpeed).
 
-    .. tip:: Occasionally, you may need to make some changes in your BIOS, such as turning off Secure Boot, or allowing USB boot for install.  See the `Community Hub <https://community.start9.com>`_ for guides or to get help.
+#. Power on your server, booting from USB.
 
-#. Finally, continue to the :ref:`Initial Setup <initial-setup>`, :ref:`Manual Update <manual-update>`, or :ref:`Reset Password <reset-password>` instructions - depending on your need.
+    .. tip:: Occasionally, you may need to make some changes in your BIOS, such as turning off Secure Boot, or allowing USB boot for install. See the `Community Hub <https://community.start9.com/>`_. for guides or to get help.
+
+#. The StartOS install wizard will now be available at ``http://start.local``. You can also use a monitor, keyboard, and mouse. This is known as "Kiosk Mode".
+
+#. Choose "Re-Install" to preserve existing StartOS data, or "Factory Reset" to start fresh. After install is complete, you will be prompted to remove the USB drive and refresh the page.

--- a/site/source/user-manual/initial-setup/initial-setup-recovery.rst
+++ b/site/source/user-manual/initial-setup/initial-setup-recovery.rst
@@ -16,6 +16,7 @@ These options assume you have a working StartOS device or data disk containing S
 
     - :ref:`Use Existing Drive <attach-drive>`
     - :ref:`Transfer <transfer-data>`
+    - :ref:`Reset Password <reset-password>`
 
 
 Emergency Restore from Backup


### PR DESCRIPTION
1. Some small tweaks and changes to make mention of ARM. 
2. Changing the Flashing process copy/headings to mirror the new docs language of Download->Verify->Flash->Install. 
3. Addressing concern that Flashing process assumed Kiosk mode and didn't mention start.local
4. Adding in link to "Reset Password" in under Recovery Options since every combination of next step is dropped from the end of the flashing guide and this was previously very had to find (and getting access again is a perfectly valid definition of "recovery").

Second pair of eyes requested when available.