### PR TITLE
iOS root CA update

### DIFF
--- a/site/source/device-guides/ios/ca-ios.rst
+++ b/site/source/device-guides/ios/ca-ios.rst
@@ -43,7 +43,9 @@ Complete this guide to trust your server's Root Certificate Authority (Root CA) 
     :width: 20%
     :alt: Profiles
 
-#. You should see green text with a check-mark saying "Verified" under the Profile Installed dialog. 
+#. You should see green text with a check-mark saying "Verified" under the Profile Installed dialog.
+
+   *Note: On recent versions of iOS this check-mark does not appear. It may return in the next version of iOS if removing it was a mistake.*
 
    .. figure:: /_static/images/ssl/ios/install_5.png
     :width: 20%

--- a/site/source/flashing-guides/os-pi.rst
+++ b/site/source/flashing-guides/os-pi.rst
@@ -51,6 +51,7 @@ Select your OS to continue:
 
                 cd Downloads
                 Get-FileHash startos-0.3.4.2-efc56c0-20230525_raspberrypi.img.gz
+                
 ____________
 
 Flash

--- a/site/source/flashing-guides/os-x86.rst
+++ b/site/source/flashing-guides/os-x86.rst
@@ -1,8 +1,8 @@
 .. _flashing-os-x86:
 
-=============
+=================
 StartOS (x86/ARM)
-=============
+=================
 This guide is for flashing StartOS to a USB drive in order to install it to an x86_64 or ARM architecture device. This will include most desktops, laptops, mini PCs, and servers.
 
  .. note:: You will need a USB drive of at least 8GB in size

--- a/site/source/service-guides/lightning/albyhub.rst
+++ b/site/source/service-guides/lightning/albyhub.rst
@@ -1,8 +1,8 @@
 .. _albyhub:
 
-=======
+=========
 Alby Hub
-=======
+=========
 
 Alby Hub is the open-source, self-custodial Lightning wallet that puts you in control. Connect to your LND or to an integrated node, it's more than just a wallet—it's your gateway to Bitcoin. Manage channels, run apps, and take charge of your funds, all through one sleek, user-friendly interface. Empower your Bitcoin journey with simplicity and sovereignty. 
 


### PR DESCRIPTION
The green checkmark is not visible on the most recent version of iOS and a few users have been confused by this. A note has been added to the guide that keeps the image (in case the checkmark comes back in the new update) and explains that the checkmark may not appear.