### PR TITLE
Update/add amazon ses Getting SMTP Credentials

### DIFF
--- a/site/source/misc-guides/smtp.rst
+++ b/site/source/misc-guides/smtp.rst
@@ -54,4 +54,11 @@ There are several StartOS services that are capable of sending emails, such as B
 
 
     .. group-tab:: Amazon SES
-        To use Amazon SES please refer to the `Amazon SES docs <https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html>`_
+
+      To use Amazon SES you will need:
+
+      * An Amazon Web Services (AWS) account. If you don't have one, you can `register here <https://aws.amazon.com/>`_ for free.
+      * To set up Amazon Simple Email Service (SES) on AWS, from `inside your AWS <https://aws.amazon.com/ses>`_ console, also free within certain limits.
+      * Optional: To purchase your own domain name to send emails from, then add the domain records Amazon provides you. This will allow you to request 'Production Access' to send emails to unverified addresses (i.e. to more than just your own email address).
+
+      You can then refer to the `Amazon SES docs <https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html>`_ to create a SMTP user. 

--- a/site/source/misc-guides/smtp.rst
+++ b/site/source/misc-guides/smtp.rst
@@ -58,7 +58,7 @@ There are several StartOS services that are capable of sending emails, such as B
       To use Amazon SES you will need:
 
       * An Amazon Web Services (AWS) account. If you don't have one, you can `register here <https://aws.amazon.com/>`_ for free.
-      * To set up Amazon Simple Email Service (SES) on AWS, from `inside your AWS <https://aws.amazon.com/ses>`_ console, also free within certain limits.
+      * To set up Amazon Simple Email Service (SES) on AWS, from `inside your AWS <https://aws.amazon.com/ses>`_ console, also free for a time within `certain limits <https://aws.amazon.com/ses/pricing/>`_.
       * Optional: To purchase your own domain name to send emails from, then add the domain records Amazon provides you. This will allow you to request 'Production Access' to send emails to unverified addresses (i.e. to more than just your own email address).
 
       You can then refer to the `Amazon SES docs <https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html>`_ to create a SMTP user. 


### PR DESCRIPTION
As discussed.

Amazon's own SES guide should definitely be linked to as it details very specific button names and UI elements that might change and might need updated over time... we should let them handle that. But... the setting up the SMTP user process happens a dozen steps after of all the things a user would have to do to even get to that. So what I've done is add a brief overview of what a user who wants to set this up would have to do before getting to the stage of creating the SMTP user, because AWS is a complex barely navigable beast. 