### PR TITLE
Invoke rsync using sudo

### DIFF
--- a/site/source/service-guides/bitcoin/blockchain-copy.rst
+++ b/site/source/service-guides/bitcoin/blockchain-copy.rst
@@ -44,7 +44,7 @@ If you have already synced the Bitcoin blockchain to the tip on one server, and 
     .. code-block:: bash
 
         cd /embassy-data/package-data/volumes/bitcoind/data/main/
-        rsync -e "ssh -i ~/.ssh/example-bbb.key" -povgr --append-verify --rsync-path="sudo mkdir -p /embassy-data/package-data/volumes/bitcoind/data/main ; sudo rsync" ./{blocks,chainstate} start9@example-bbb.local:/embassy-data/package-data/volumes/bitcoind/data/main/
+        sudo rsync -e "ssh -i ~/.ssh/example-bbb.key" -povgr --append-verify --rsync-path="sudo mkdir -p /embassy-data/package-data/volumes/bitcoind/data/main ; sudo rsync" ./{blocks,chainstate} start9@example-bbb.local:/embassy-data/package-data/volumes/bitcoind/data/main/
 
 #. Wait some hours until the copy is complete.  On a gigabit network, the limiting factor will be the write speed of your SSD on the receiving server.  When it is complete, clean up a bit:
 


### PR DESCRIPTION
This sudo is not necessary, unless the user is trying to invoke the command as an unprivileged user.  This wouldn't happen if they're working through the guide exactly in sequence, but if the transfer is interrupted and they just ssh back in, they may forget to perform the sudo command in the previous steps, so this will be necessary.  It was already confusing for at least [one user](https://github.com/Start9Labs/documentation/issues/646), and there's no harm in adding it.   While not necessarily necessary (😉) it won't hurt even if the user is already root, and it's required for it to work if they aren't.