### PR TITLE
Fix numbering on Bonjour instructions

### DIFF
--- a/site/source/user-manual/connecting-lan.rst
+++ b/site/source/user-manual/connecting-lan.rst
@@ -22,11 +22,11 @@ Windows only
 ------------
 On Windows, it is necessary to install Bonjour Print Services in order to access the `.local` URLs of your installed services. In a future release of StartOS, this will no longer be necessary.
 
-#. Download the `Bonjour installer </_static/bin/Bonjour64.msi>`_.
+1. Download the `Bonjour installer </_static/bin/Bonjour64.msi>`_.
 
 .. note:: The Bonjour installer linked above, which Apple bundles into iTunes, is hosted by Start9 for your convenience.  If you wish to obtain it directly from Apple to be more confident of its provenance, download `iTunes64 <https://www.apple.com/itunes/download/win64>`_ from Apple's official website and extract the files using a tool such as WinRAR. If you do not have WinRAR installed, you can download `here <https://www.win-rar.com/download.html>`_.
 
-#. Run the **Bonjour64** package to install it.
+2. Run the **Bonjour64** package to install it.
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
Due to the gap caused by the note between the `#`s, the steps were just rendering as two number `1`s, visible here for now:
https://docs.start9.com/0.3.5.x/user-manual/connecting-lan#windows-only

Manually entering the step # should fix that.
