### PR TITLE
feat: add reboot suggestion on chrome-based cert add

### DIFF
--- a/site/source/misc-guides/ca-chrome.rst
+++ b/site/source/misc-guides/ca-chrome.rst
@@ -13,4 +13,4 @@ This guide applies to Chrome, Chromium, Brave, Vivaldi and any other Chrome-base
 #. Find and select your *adjective-noun.crt* file
 #. Check “Trust this certificate for identifying websites”
 #. Select OK
-
+#. You may need to restart your browser or computer for the changes to take effect.


### PR DESCRIPTION
During the previous 2 server configurations, I found it was necessary to reboot the computer for the certificate to be recognized and the "Not secure" message to go away.

I thought this line might save new users some frustration.