### PR TITLE
Update 0351 ISOs Link

### DIFF
--- a/site/source/flashing-guides/os-pi.rst
+++ b/site/source/flashing-guides/os-pi.rst
@@ -9,7 +9,7 @@ This guide is for flashing StartOS to a microSD card in order to install it on a
 
 Download StartOS
 -----------------
-Visit the `Github release page <https://github.com/Start9Labs/start-os/releases/latest>`_ to find the latest StartOS release.
+Visit the `Github release page <https://github.com/Start9Labs/start-os/releases/tag/v0.3.5.1>`_ to find the latest StartOS release.
 
 At the bottom of the page, under "Assets," download the ``startos-..._raspberrypi.img.gz`` file.
 

--- a/site/source/flashing-guides/os-x86.rst
+++ b/site/source/flashing-guides/os-x86.rst
@@ -9,7 +9,7 @@ This guide is for flashing StartOS to a USB drive in order to install it to an x
 
 Download StartOS
 -----------------
-Visit the `Github release page <https://github.com/Start9Labs/start-os/releases/latest>`_ to find the latest StartOS release.
+Visit the `Github release page <https://github.com/Start9Labs/start-os/releases/tag/v0.3.5.1>`_ to find the latest StartOS release.
 
 At the bottom of the page, under "Assets," download the ``x86_64.iso`` or ``x86_64-nonfree.iso`` file.
 


### PR DESCRIPTION
Now that 040 beta is out of alpha/"pre-release" phase, the releases/latest link points to them instead of 0351.
This points the 0351 docs to the 0351 isos.